### PR TITLE
Fixes for the VC Bundle with Git on Windows

### DIFF
--- a/git-windows/vc.bat
+++ b/git-windows/vc.bat
@@ -18,7 +18,7 @@ if "%1" NEQ "" (
 )
 REM English locale.
 set LC_ALL=C
-git --no-pager log -1 HEAD --pretty=format:"Hash: %H%nAbr. Hash: %h%nParent Hashes: %P%nAbr. Parent Hashes: %p%nAuthor Name: %an%nAuthor Email: %ae%nAuthor Date: %ai%nCommitter Name: %cn%nCommitter Email: %ce%nCommitter Date: %ci%n" |gawk -v script=log -v full=%full% -f vc-git.awk > vc.tex
+git --no-pager log -1 HEAD --pretty=format:"Hash: %%H%%nAbr. Hash: %%h%%nParent Hashes: %%P%%nAbr. Parent Hashes: %%p%%nAuthor Name: %%an%%nAuthor Email: %%ae%%nAuthor Date: %%ai%%nCommitter Name: %%cn%%nCommitter Email: %%ce%%nCommitter Date: %%ci%%n" |gawk -v script=log -v full=%full% -f vc-git.awk > vc.tex
 if "%mod%"=="1" (
   git status --porcelain=v1 |gawk -v script=status -f vc-git.awk >> vc.tex
 )

--- a/git-windows/vc.bat
+++ b/git-windows/vc.bat
@@ -18,7 +18,7 @@ if "%1" NEQ "" (
 )
 REM English locale.
 set LC_ALL=C
-git --no-pager log -1 HEAD --pretty=format:"Hash: %%H%%nAbr. Hash: %%h%%nParent Hashes: %%P%%nAbr. Parent Hashes: %%p%%nAuthor Name: %%an%%nAuthor Email: %%ae%%nAuthor Date: %%ai%%nCommitter Name: %%cn%%nCommitter Email: %%ce%%nCommitter Date: %%ci%%n" |gawk -v script=log -v full=%full% -f vc-git.awk > vc.tex
+git --no-pager log -1 HEAD --pretty=format:"Hash: %%H%%nAbrHash: %%h%%nParentHashes: %%P%%nAbrParentHashes: %%p%%nAuthorName: %%an%%nAuthorEmail: %%ae%%nAuthorDate: %%ai%%nCommitterName: %%cn%%nCommitterEmail: %%ce%%nCommitterDate: %%ci%%n" | gawk -v script=log -v full=%full% -f vc-git.awk > vc.tex
 if "%mod%"=="1" (
   git status --porcelain=v1 |gawk -v script=status -f vc-git.awk >> vc.tex
 )


### PR DESCRIPTION
There were a couple of issues that meant that functionality of the vc bundle when using `git` on Windows just didn't work at all.

I have opened #2 and #3 to report these issues, and since the issues are fairly simple to fix I have opened this PR with my suggestions.

However, in light of this it may be worth checking the consistency of the other platforms and version control types. I would do this, but I only work with `git`.

**EDIT**:
I've browsed the source, and it seems that only the mercurial template uses `Abr. Hash:` rather than `AbrHash:` etc. I still think moving `git-windows/vc.bat` inline with `git-unix/vc` is the right call so there are no differences between the `vc-git.awk` files.

**EDIT 2**:
I've also checked the rest of the `.bat` files, and none of the rest of them need escaping either.